### PR TITLE
Removed DB context from deck service

### DIFF
--- a/backend/noava/noava/Controllers/Decks/DeckController.cs
+++ b/backend/noava/noava/Controllers/Decks/DeckController.cs
@@ -175,7 +175,7 @@ namespace noava.Controllers
         }
 
 
-        [HttpPost("join/{joinCode}")]
+        [HttpPost("join/{joinCode}/{isOwner}")]
         public async Task<ActionResult<DeckResponse>> JoinByCode(
             string joinCode,
             [FromQuery] bool isOwner = false)  

--- a/backend/noava/noava/Repositories/Decks/DeckRepository.cs
+++ b/backend/noava/noava/Repositories/Decks/DeckRepository.cs
@@ -158,5 +158,29 @@ namespace noava.Repositories
             _context.DecksUsers.Remove(deckUser);
             await _context.SaveChangesAsync();
         }
+
+        public async Task<List<Deck>> GetUserDecksWithAccessAsync(string userId, int? limit = null)
+        {
+            var query = _context.Decks
+                .Where(d =>
+                    // User created the deck
+                    d.UserId == userId ||
+                    // OR user has access via DeckUsers (owner OR invited)
+                    d.DeckUsers.Any(du => du.ClerkId == userId))
+                .OrderByDescending(d => d.CreatedAt)
+                .AsQueryable();
+
+            if (limit.HasValue)
+            {
+                query = query.Take(limit.Value);
+            }
+
+            return await query.ToListAsync();
+        }
+        public async Task UpdateDeckUserAsync(DeckUser deckUser)
+        {
+            _context.DecksUsers.Update(deckUser);
+            await _context.SaveChangesAsync();
+        }
     }
 }

--- a/backend/noava/noava/Repositories/Decks/IDeckRepository.cs
+++ b/backend/noava/noava/Repositories/Decks/IDeckRepository.cs
@@ -22,6 +22,8 @@ namespace noava.Repositories.Decks
         Task<bool> HasAccessAsync(int deckId, string userId);
         Task AddAsync(DeckUser deckUser);
         Task RemoveAsync(DeckUser deckUser);
+        Task<List<Deck>> GetUserDecksWithAccessAsync(string userId, int? limit = null);
+        Task UpdateDeckUserAsync(DeckUser deckUser);
 
     }
 }


### PR DESCRIPTION
This pull request refactors and improves the handling of deck membership and user invitations in the deck management backend. The main themes are repository abstraction, improved update logic for deck membership (especially owner status), and cleaner service implementation.

**Repository abstraction and new methods:**

* Added `GetUserDecksWithAccessAsync` and `UpdateDeckUserAsync` methods to the `IDeckRepository` interface and its implementation, enabling retrieval of all decks a user can access and updating deck membership, respectively. [[1]](diffhunk://#diff-34865db1f7dfe82b22b6ae72545065a96cdfe1291d86ab0a610129b36b8ebdc5R25-R26) [[2]](diffhunk://#diff-7177eb17262fbd8191f8c956e3b55862b77d0ab935c32e24707c04c07b564a80R161-R184)

**Service layer refactoring:**

* Refactored `DeckService` to remove direct dependencies on `NoavaDbContext` and instead use repository methods for all data access, including deck retrieval and membership updates. This improves separation of concerns and testability. [[1]](diffhunk://#diff-e955c215c0b8eb31382d8b1b37067cc007c86c95b2eb07a9de5972f6ece6d287L41) [[2]](diffhunk://#diff-e955c215c0b8eb31382d8b1b37067cc007c86c95b2eb07a9de5972f6ece6d287L52-R51) [[3]](diffhunk://#diff-e955c215c0b8eb31382d8b1b37067cc007c86c95b2eb07a9de5972f6ece6d287L64)
* Updated `GetUserDecksAsync` to use the new repository method, simplifying the logic and ensuring consistency.

**Membership and invitation logic improvements:**

* Modified invitation and join logic to use repository methods for checking and updating membership, and to update the owner status of an existing member if necessary. This ensures that changes to ownership are handled consistently and atomically. [[1]](diffhunk://#diff-e955c215c0b8eb31382d8b1b37067cc007c86c95b2eb07a9de5972f6ece6d287L289-L329) [[2]](diffhunk://#diff-e955c215c0b8eb31382d8b1b37067cc007c86c95b2eb07a9de5972f6ece6d287L372-L411)
* Changed the join endpoint and notification to pass `isOwner` as a path parameter instead of a query parameter, ensuring clearer and more RESTful API design. [[1]](diffhunk://#diff-6e5bfc50ab0691846599f9a770ecd0d21f30ad3daa5868f5a92fd349a2792bfcL178-R178) [[2]](diffhunk://#diff-e955c215c0b8eb31382d8b1b37067cc007c86c95b2eb07a9de5972f6ece6d287L342-R309)