### PR TITLE
refactor: remove NoavaFooter from multiple pages

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import { useLocation } from 'react-router-dom';
 import { I18nextProvider } from 'react-i18next';
 import i18next from 'i18next';
 import NoavaSidebar from './shared/components/navigation/NoavaSidebar';
+import NoavaFooter from './shared/components/navigation/NoavaFooter';
 import { Drawer } from 'flowbite-react';
 import { HiX } from 'react-icons/hi';
 import { RxHamburgerMenu } from 'react-icons/rx';
@@ -77,6 +78,7 @@ function App() {
 
           <main className="flex-1 overflow-auto">
             <AppRoutes />
+            {!showSidebar && <NoavaFooter />}
           </main>
         </div>
       </I18nextProvider>

--- a/frontend/src/pages/Classrooms/Classrooms.tsx
+++ b/frontend/src/pages/Classrooms/Classrooms.tsx
@@ -3,7 +3,6 @@ import { useNavigate } from 'react-router-dom';
 import { Button, Select, Tooltip } from 'flowbite-react';
 import { HiPlus } from 'react-icons/hi';
 import { useTranslation } from 'react-i18next';
-import NoavaFooter from '../../shared/components/navigation/NoavaFooter';
 import PageHeader from '../../shared/components/PageHeader';
 import ClassroomCard from '../../shared/components/ClassroomCard';
 import ClassroomModal from '../../shared/components/ClassroomModal';
@@ -294,8 +293,6 @@ function ClassroomsPage() {
           onConfirm={confirmRequestNewCode}
           onCancel={() => setRequestCodeId(null)}
         />
-
-        <NoavaFooter />
       </div>
     </div>
   );

--- a/frontend/src/pages/Classrooms/JoinClassroom.tsx
+++ b/frontend/src/pages/Classrooms/JoinClassroom.tsx
@@ -3,7 +3,6 @@ import { Button, Label, TextInput, Card, Spinner } from 'flowbite-react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import PageHeader from '../../shared/components/PageHeader';
-import NoavaFooter from '../../shared/components/navigation/NoavaFooter';
 import { useClassroomService } from '../../services/ClassroomService';
 import { useToast } from '../../contexts/ToastContext';
 import FormErrorMessage from '../../shared/components/validation/FormErrorMessage';
@@ -99,8 +98,6 @@ export default function JoinClassroom() {
             </Card>
           </div>
         </section>
-
-        <NoavaFooter />
       </div>
     </div>
   );

--- a/frontend/src/pages/Classrooms/Members.tsx
+++ b/frontend/src/pages/Classrooms/Members.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import PageHeader from '../../shared/components/PageHeader';
-import NoavaFooter from '../../shared/components/navigation/NoavaFooter';
 import Loading from '../../shared/components/loading/Loading';
 import { HiArrowLeft } from 'react-icons/hi';
 import { Button, Tooltip } from 'flowbite-react';
@@ -230,8 +229,6 @@ export default function MembersPage() {
           onInvite={handleInvite}
           canInvite={classroom.permissions?.canEdit}
         />
-
-        <NoavaFooter />
       </div>
     </div>
   );

--- a/frontend/src/pages/Decks/Decks.tsx
+++ b/frontend/src/pages/Decks/Decks.tsx
@@ -13,7 +13,6 @@ import { Modal } from 'flowbite-react';
 import { HiPlus, HiPlay, HiPencil, HiRefresh, HiChevronDown } from 'react-icons/hi';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
-import NoavaFooter from '../../shared/components/navigation/NoavaFooter';
 import PageHeader from '../../shared/components/PageHeader';
 import DeckCard from '../../shared/components/DeckCard';
 import DeckModal from '../../shared/components/DeckModal';
@@ -509,8 +508,6 @@ function DecksPage() {
                   onConfirm={handleConfirmCopy}
                   onCancel={() => setCopyModalOpened(false)}
                 />
-
-        <NoavaFooter />
       </div>
     </div>
   );

--- a/frontend/src/pages/FAQ/FAQ.tsx
+++ b/frontend/src/pages/FAQ/FAQ.tsx
@@ -258,8 +258,6 @@ function FAQPage() {
           )}
         </div>
       </section>
-
-      <NoavaFooter />
     </>
   );
 }

--- a/frontend/src/pages/Flashcards/FlashcardDetail.tsx
+++ b/frontend/src/pages/Flashcards/FlashcardDetail.tsx
@@ -16,7 +16,6 @@ import { useUser } from '@clerk/clerk-react';
 import { useDeckService } from '../../services/DeckService';
 import { useFlashcardService } from '../../services/FlashcardService';
 import { useToast } from '../../contexts/ToastContext';
-import NoavaFooter from '../../shared/components/navigation/NoavaFooter';
 import FlashcardModal from '../../shared/components/FlashcardModal';
 import type { Deck } from '../../models/Deck';
 import type {
@@ -638,8 +637,6 @@ function FlashcardDetail() {
             onUpdate={fetchDeck}
           />
         )}
-
-        <NoavaFooter />
       </div>
     </div>
   );

--- a/frontend/src/pages/Home/Home.tsx
+++ b/frontend/src/pages/Home/Home.tsx
@@ -1,6 +1,5 @@
 import Header from '../../shared/components/navigation/Header';
 import { Button, Card } from 'flowbite-react';
-import NoavaFooter from '../../shared/components/navigation/NoavaFooter';
 import {
   HiCube,
   HiUserGroup,
@@ -168,8 +167,6 @@ function Home() {
           </div>
         </div>
       </section>
-
-      <NoavaFooter />
     </>
   );
 }

--- a/frontend/src/pages/Legal/LegalLayout.tsx
+++ b/frontend/src/pages/Legal/LegalLayout.tsx
@@ -1,5 +1,4 @@
 import { ReactNode } from 'react';
-import NoavaFooter from '../../shared/components/navigation/NoavaFooter';
 import Header from '../../shared/components/navigation/Header';
 
 type LegalLayoutProps = {
@@ -21,7 +20,6 @@ function LegalLayout({ title, lastModifiedDate, children }: LegalLayoutProps) {
         </h4>
         {children}
       </div>
-      <NoavaFooter />
     </>
   );
 }

--- a/frontend/src/pages/NotFound/NotFound.tsx
+++ b/frontend/src/pages/NotFound/NotFound.tsx
@@ -2,7 +2,6 @@ import { Card } from 'flowbite-react';
 import { HiHome, HiQuestionMarkCircle } from 'react-icons/hi';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
-import NoavaFooter from '../../shared/components/navigation/NoavaFooter';
 
 function NotFound() {
   const { t } = useTranslation('common');
@@ -70,7 +69,6 @@ function NotFound() {
           </div>
         </div>
       </div>
-      <NoavaFooter />
     </>
   );
 }

--- a/frontend/src/pages/Settings/Settings.tsx
+++ b/frontend/src/pages/Settings/Settings.tsx
@@ -13,7 +13,6 @@ import { SettingsGroup } from './components/SettingsGroup';
 import { useTranslation } from 'react-i18next';
 import { Tooltip, Dropdown, DropdownItem } from 'flowbite-react';
 import { useTheme } from '../../contexts/ThemeContext';
-import NoavaFooter from '../../shared/components/navigation/NoavaFooter';
 import { useUserService } from '../../services/UserService';
 import { useToast } from '../../contexts/ToastContext';
 import Loading from '../../shared/components/loading/Loading';
@@ -203,12 +202,11 @@ function SettingsPage() {
                 active: !emailPreferences,
                 onClick: () => emailPreferences && !updatingPreferences && handleEmailPreferenceChange(),
               },
-            ]}
+]}
           />
         </div>
         )}
       </div>
-      <NoavaFooter />
     </>
   );
 }

--- a/frontend/src/shared/components/loading/Skeleton.tsx
+++ b/frontend/src/shared/components/loading/Skeleton.tsx
@@ -1,4 +1,3 @@
-import NoavaFooter from '../navigation/NoavaFooter';
 import PageHeader from '../PageHeader';
 
 function Skeleton() {
@@ -24,7 +23,6 @@ function Skeleton() {
             </div>
           </div>
         </div>
-        <NoavaFooter />
       </div>
     </div>
   );


### PR DESCRIPTION
This pull request refactors how the `NoavaFooter` component is included in the frontend application. Previously, `NoavaFooter` was manually rendered at the bottom of many individual pages. Now, it is conditionally rendered once in the main layout, ensuring a consistent footer across all pages and simplifying page components by removing redundant code.

**Layout and Footer Refactor:**

* Added `NoavaFooter` import and conditional rendering to the main application layout in `App.tsx`, so the footer is displayed on all pages except when the sidebar is shown. [[1]](diffhunk://#diff-e56cb91573ddb6a97ecd071925fe26504bb5a65f921dc64c63e534162950e1ebR9) [[2]](diffhunk://#diff-e56cb91573ddb6a97ecd071925fe26504bb5a65f921dc64c63e534162950e1ebR81)

**Page Component Clean-up:**

* Removed direct imports and usage of `NoavaFooter` from the following page components, as the footer is now handled globally:
  - `ClassroomsPage`, `JoinClassroom`, `MembersPage` [[1]](diffhunk://#diff-645e4cfe8c92c6f075d9f24bfc66b92f2f26362dcf9895989e73c3ed82973a68L6) [[2]](diffhunk://#diff-645e4cfe8c92c6f075d9f24bfc66b92f2f26362dcf9895989e73c3ed82973a68L297-L298) [[3]](diffhunk://#diff-5f921c3cc2cc25afecb746cbf9261569c82a7a029586faf7c6063efc29e56868L6) [[4]](diffhunk://#diff-5f921c3cc2cc25afecb746cbf9261569c82a7a029586faf7c6063efc29e56868L102-L103) [[5]](diffhunk://#diff-0548db11c0828cc4a08866d06221ca23abb3cafe8b0dc1d4ae9233730b09ab7cL4) [[6]](diffhunk://#diff-0548db11c0828cc4a08866d06221ca23abb3cafe8b0dc1d4ae9233730b09ab7cL233-L234)
  - `DecksPage`, `FlashcardDetail` [[1]](diffhunk://#diff-ac488dd31e3795798c01802fbc4fb1f95f71c546d7dffb7882ae944ea75be6bdL16) [[2]](diffhunk://#diff-ac488dd31e3795798c01802fbc4fb1f95f71c546d7dffb7882ae944ea75be6bdL512-L513) [[3]](diffhunk://#diff-320e41f8ba2e2279e0cf113bce47f031c5b01ebd62d3ec73b3239d42c7c2884aL19) [[4]](diffhunk://#diff-320e41f8ba2e2279e0cf113bce47f031c5b01ebd62d3ec73b3239d42c7c2884aL641-L642)
  - `Home`, `FAQPage`, `LegalLayout`, `NotFound`, `SettingsPage` [[1]](diffhunk://#diff-82b44766bc67b5af328f29065a1c8e3abf9cc8dd39b443425f7975ee747b4053L3) [[2]](diffhunk://#diff-82b44766bc67b5af328f29065a1c8e3abf9cc8dd39b443425f7975ee747b4053L171-L172) [[3]](diffhunk://#diff-3a1ed820afd7fcf98335667f250f2105145d3f45aa1670d438670b030b4d684dL261-L262) [[4]](diffhunk://#diff-0b695696abc2fdc2c083285a6478b6b5ea86fcdbdfe558df2972c98c011cb3a8L2) [[5]](diffhunk://#diff-0b695696abc2fdc2c083285a6478b6b5ea86fcdbdfe558df2972c98c011cb3a8L24) [[6]](diffhunk://#diff-060bf6a52c40b0e838eea05a684ea9e9bf05027a5b5da759691c743d93b7bd59L5) [[7]](diffhunk://#diff-060bf6a52c40b0e838eea05a684ea9e9bf05027a5b5da759691c743d93b7bd59L73) [[8]](diffhunk://#diff-2e22efcaf9029e797771bda2d02b52ea20d12f85a99f39c0d50194640dca9925L16) [[9]](diffhunk://#diff-2e22efcaf9029e797771bda2d02b52ea20d12f85a99f39c0d50194640dca9925L211)
  - `Skeleton` loading component [[1]](diffhunk://#diff-7761866b266417d298a67b1d14997434a9c0fab63839af76831f563929d4dff1L1) [[2]](diffhunk://#diff-7761866b266417d298a67b1d14997434a9c0fab63839af76831f563929d4dff1L27)

This change centralizes the footer logic, reduces code duplication, and ensures any future updates to the footer only need to be made in one place.