### PR TITLE
Enhance badges in review components with icons and updated colors

### DIFF
--- a/frontend/src/pages/Review/Quickreview.tsx
+++ b/frontend/src/pages/Review/Quickreview.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
 import { Button, Progress, Badge } from 'flowbite-react';
 import { HiArrowLeft, HiRefresh, HiX, HiVolumeUp, HiPlay } from 'react-icons/hi';
+import { FaRepeat } from 'react-icons/fa6';
 import { useTranslation } from 'react-i18next';
 import { useDeckService } from '../../services/DeckService';
 import { useFlashcardService } from '../../services/FlashcardService';
@@ -310,11 +311,10 @@ function QuickReview() {
                   {session.deckTitle}
                 </h1>
                 <div className="flex gap-2 mt-1">
-                  <Badge color="info" className="mt-1">
+                  <Badge color="success" icon={FaRepeat}>
                     {isBulkReview ? t('quickReview.bulkMode') : t('quickReview.mode')}
                   </Badge>
-                  <Badge color="cyan">
-                    <HiPlay className="w-3 h-3 mr-1" />
+                  <Badge color="cyan" icon={HiPlay}>
                     {t('quickReview.flipMode')}
                   </Badge>
                 </div>

--- a/frontend/src/pages/Review/ReverseReview.tsx
+++ b/frontend/src/pages/Review/ReverseReview.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
 import { Button, Progress, Badge } from 'flowbite-react';
 import { HiArrowLeft, HiRefresh, HiX, HiVolumeUp } from 'react-icons/hi';
+import { FaRepeat } from 'react-icons/fa6';
 import { useTranslation } from 'react-i18next';
 import { useDeckService } from '../../services/DeckService';
 import { useFlashcardService } from '../../services/FlashcardService';
@@ -304,11 +305,10 @@ function ReverseReview() {
                   {session.deckTitle}
                 </h1>
                 <div className="flex gap-2 mt-1">
-                  <Badge color="info">
+                  <Badge color="success" icon={FaRepeat}>
                     {isBulkReview ? t('quickReview.bulkMode') : t('quickReview.mode')}
                   </Badge>
-                  <Badge color="cyan">
-                    <HiRefresh className="w-3 h-3 mr-1" />
+                  <Badge color="cyan" icon={HiRefresh}>
                     {t('quickReview.reverseMode')}
                   </Badge>
                 </div>

--- a/frontend/src/pages/Review/WriteReview.tsx
+++ b/frontend/src/pages/Review/WriteReview.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
 import { Button, Progress, Badge, TextInput, Alert } from 'flowbite-react';
 import { HiArrowLeft, HiRefresh, HiX, HiVolumeUp, HiCheckCircle, HiXCircle, HiPencil } from 'react-icons/hi';
+import { FaRepeat } from 'react-icons/fa6';
 import { useTranslation } from 'react-i18next';
 import { useDeckService } from '../../services/DeckService';
 import { useFlashcardService } from '../../services/FlashcardService';
@@ -345,11 +346,10 @@ function WriteReview() {
                   {session.deckTitle}
                 </h1>
                 <div className="flex gap-2 mt-1">
-                  <Badge color="info">
+                  <Badge color="success" icon={FaRepeat}>
                     {isBulkReview ? t('quickReview.bulkMode') : t('quickReview.mode')}
                   </Badge>
-                  <Badge color="cyan">
-                    <HiPencil className="w-3 h-3 mr-1" />
+                  <Badge color="cyan" icon={HiPencil}>
                     {t('quickReview.writeMode')}
                   </Badge>
                 </div>


### PR DESCRIPTION
This pull request updates the badge icons and colors in the review pages to improve visual consistency and clarity. The most important changes are the introduction of the `FaRepeat` icon for bulk review mode and the use of relevant icons for each review mode badge.

Badge icon and color updates:

* All review pages (`Quickreview.tsx`, `ReverseReview.tsx`, `WriteReview.tsx`): The bulk review mode badge now uses the `FaRepeat` icon and the `success` color instead of `info` for improved visibility. [[1]](diffhunk://#diff-c80bb26dcb3f669cd235fdc40159f4e7630889e024ba068a0c6bf35550139467L313-R317) [[2]](diffhunk://#diff-ea4159eae0046ebf7ca2768e5274d8d8056e80c11bed80d2d8375f3fdbc36eb7L307-R311) [[3]](diffhunk://#diff-980fa9231a7fbc85acb2fc582ab1f9da8318618dd550cd22673843c0ccbf17e0L348-R352)
* Review mode badges in each page now use their respective icons (`HiPlay` for flip mode, `HiRefresh` for reverse mode, `HiPencil` for write mode) instead of manual icon placement, resulting in cleaner code and consistent appearance. [[1]](diffhunk://#diff-c80bb26dcb3f669cd235fdc40159f4e7630889e024ba068a0c6bf35550139467L313-R317) [[2]](diffhunk://#diff-ea4159eae0046ebf7ca2768e5274d8d8056e80c11bed80d2d8375f3fdbc36eb7L307-R311) [[3]](diffhunk://#diff-980fa9231a7fbc85acb2fc582ab1f9da8318618dd550cd22673843c0ccbf17e0L348-R352)

Icon import additions:

* Added `FaRepeat` icon import from `react-icons/fa6` in all three review components to support the updated badge icons. [[1]](diffhunk://#diff-c80bb26dcb3f669cd235fdc40159f4e7630889e024ba068a0c6bf35550139467R5) [[2]](diffhunk://#diff-ea4159eae0046ebf7ca2768e5274d8d8056e80c11bed80d2d8375f3fdbc36eb7R5) [[3]](diffhunk://#diff-980fa9231a7fbc85acb2fc582ab1f9da8318618dd550cd22673843c0ccbf17e0R5)