### PR TITLE
Enhance AddDeckModal to filter existing decks when adding to classroom

### DIFF
--- a/frontend/src/pages/Classrooms/ClassroomDetail.tsx
+++ b/frontend/src/pages/Classrooms/ClassroomDetail.tsx
@@ -354,6 +354,7 @@ function ClassroomDetailPage() {
             fetchDecks();
           }}
           onAddDeck={handleAddDeckToClassroom}
+          existingDeckIds={decks.map(deck => deck.deckId)}
         />
 
         {/* Bulk Review Modal */}

--- a/frontend/src/shared/components/AddDeckModal.tsx
+++ b/frontend/src/shared/components/AddDeckModal.tsx
@@ -13,13 +13,15 @@ interface AddDeckModalProps {
   classroomId: number;
   onDeckAdded: () => void;
   onAddDeck: (deckId: number) => Promise<void>;
+  existingDeckIds?: number[];
 }
 
 export const AddDeckModal: React.FC<AddDeckModalProps> = ({
   opened,
   onClose,
   onDeckAdded,
-  onAddDeck
+  onAddDeck,
+  existingDeckIds = []
 }) => {
   const { t } = useTranslation('classrooms');
   const deckService = useDeckService();
@@ -54,8 +56,11 @@ export const AddDeckModal: React.FC<AddDeckModalProps> = ({
     setLoading(true);
     try {
       const data = await deckService.getMyDecks();
-      setDecks(data);
-      setFilteredDecks(data);
+      const availableDecks = data.filter(
+        deck => !existingDeckIds.includes(deck.deckId)
+      );
+      setDecks(availableDecks);
+      setFilteredDecks(availableDecks);
     } catch (error) {
       console.error('Error loading decks:', error);
       showError(t('addDeck.loadError'), t('app.error'));


### PR DESCRIPTION
This pull request enhances the `AddDeckModal` component to prevent users from adding decks that are already part of the classroom. The changes ensure that only decks not currently associated with the classroom are available for selection in the modal.

**Improvements to deck selection in AddDeckModal:**

* The `AddDeckModal` component now accepts an `existingDeckIds` prop, which is a list of deck IDs already present in the classroom. This allows the modal to filter out decks that have already been added.
* When loading decks in the modal, it filters out any decks whose IDs are included in `existingDeckIds`, ensuring users cannot add duplicates.
* The `ClassroomDetailPage` passes the current classroom's deck IDs to the `AddDeckModal` via the new `existingDeckIds` prop, enabling the filtering logic.