### PR TITLE
Refactor DashboardStatisticsResponse to use double for TimeSpentHours

### DIFF
--- a/backend/noava/noava/DTOs/Statistics/DashboardStatisticsResponse.cs
+++ b/backend/noava/noava/DTOs/Statistics/DashboardStatisticsResponse.cs
@@ -4,7 +4,7 @@
     {
         public int CardsReviewed { get; set; }
         public double AccuracyRate { get; set; }
-        public int TimeSpentHours { get; set; }
+        public double TimeSpentHours { get; set; }
         public DateTime? LastRevieweDate { get; set; }
     }
 }

--- a/backend/noava/noava/Services/Statistics/General/StatsService.cs
+++ b/backend/noava/noava/Services/Statistics/General/StatsService.cs
@@ -41,7 +41,7 @@ namespace noava.Services.Statistics.General
                 CardsReviewed = totalCardsReviewed,
                 AccuracyRate = accuracyRate,
                 LastRevieweDate = lastReviewedAt,
-                TimeSpentHours = (int) totalTimeHours
+                TimeSpentHours = Math.Round(totalTimeHours, 2)
             };
         }
     }

--- a/frontend/src/pages/Dashboard/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard/Dashboard.tsx
@@ -15,7 +15,7 @@ import { useNavigate } from 'react-router-dom';
 import { useDeckService } from '../../services/DeckService';
 import { useClassroomService } from '../../services/ClassroomService';
 import { useStatisticsService } from '../../services/StatisticsService';
-import { formatDateToEuropean } from '../../services/DateService';
+import { formatDateToEuropean, formatHoursToTime } from '../../services/DateService';
 import type { DeckRequest, Deck } from '../../models/Deck';
 import type { ClassroomResponse } from '../../models/Classroom';
 import type {
@@ -70,6 +70,7 @@ function Dashboard() {
         classroomService.getAllForUser(2),
         statisticsService.getGeneralStatistics(),
       ]);
+      console.log(statsData)
       setDecks(decksData);
       setClassrooms(classroomsData);
       setStatistics(statsData);
@@ -215,7 +216,7 @@ function Dashboard() {
                   />
                   <DashboardStatCard
                     title={t('statcard.studytime.title')}
-                    value={`${statistics.timeSpentHours}h`}
+                    value={formatHoursToTime(statistics.timeSpentHours || 0)}
                     tooltip={t('statcard.studytime.tooltip')}
                     icon={LuClock}
                   />

--- a/frontend/src/services/DateService.ts
+++ b/frontend/src/services/DateService.ts
@@ -35,4 +35,17 @@ export const formatTimeSpent = (seconds: number): string => {
   return `${minutes}m`;
 };
 
-export default { formatDateToEuropean, formatResponseTime, formatTimeSpent };
+export const formatHoursToTime = (hours: number): string => {
+  const wholeHours = Math.floor(hours);
+  const minutes = Math.round((hours - wholeHours) * 60);
+  
+  if (wholeHours === 0) {
+    return `${minutes}m`;
+  } else if (minutes === 0) {
+    return `${wholeHours}h`;
+  } else {
+    return `${wholeHours}h ${minutes}m`;
+  }
+};
+
+export default { formatDateToEuropean, formatResponseTime, formatTimeSpent, formatHoursToTime };


### PR DESCRIPTION
This pull request improves the handling and display of study time statistics across both the backend and frontend. The main focus is on representing study time as a floating-point value (to allow for fractions of hours), rounding it appropriately, and formatting it for clearer display in the dashboard UI.

**Backend improvements to study time data:**

* Changed the `TimeSpentHours` property in `DashboardStatisticsResponse` from `int` to `double` to support fractional hours.
* Updated the assignment of `TimeSpentHours` in `StatsService` to use `Math.Round(totalTimeHours, 2)` instead of casting to `int`, ensuring the value is rounded to two decimal places.

**Frontend improvements to study time formatting and display:**

* Added a new utility function `formatHoursToTime` in `DateService.ts` to convert fractional hours into a human-readable string (e.g., "1h 30m").
* Updated the dashboard to use `formatHoursToTime` when displaying study time, replacing the previous simple hours display.
* Imported the new formatting function in the dashboard page and added a debug log for statistics data. [[1]](diffhunk://#diff-6858a96b0d806bae8da7a4734e00028af776840d41cce581ee80129238bdeedeL18-R18) [[2]](diffhunk://#diff-6858a96b0d806bae8da7a4734e00028af776840d41cce581ee80129238bdeedeR73)